### PR TITLE
Fix commit message body blank lines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Dominik Aschbacher
+Copyright (c) 2021 Dominik Aschbacher
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     name: GitLint
     steps:
       - name: Lint commits, branches, and pull requests
-        uses: aschbacd/gitlint-action@v1.0.0
+        uses: aschbacd/gitlint-action@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           commit-message-body-max-length: 72
@@ -43,6 +43,7 @@ The following input keys can be used in your GitHub Actions workflow (shown abov
 | commit-message-subject-max-length  | Max. characters for commit message subject                   | -1 (disabled)           | 50                            |
 | commit-message-subject-min-length  | Min. characters for commit message subject                   | -1 (disabled)           | -1 (disabled)                 |
 | github-token                       | Token used to authenticate against GitHub api                | `-`                     | `${{ secrets.GITHUB_TOKEN }}` |
+| prohibit-blank-lines-cm-body       | Commit message body cannot include blank lines               | `false`                 | `false`                       |
 | prohibit-unknown-commit-authors    | Commit author must be GitHub user                            | `false`                 | `true`                        |
 | prohibit-unknown-commit-committers | Commit committer must be GitHub user                         | `false`                 | `true`                        |
 | prohibit-unsigned-commits          | Commits without a valid signature are invalid                | `false`                 | `false`                       |

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   github-token:
     description: "GitHub token used to access api"
     required: true
+  prohibit-blank-lines-cm-body:
+    description: "Prohibit blank lines in commit message body"
+    required: false
+    default: false
   prohibit-unknown-commit-authors:
     description: "Prohibit commit authors that are not known to GitHub"
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlint-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlint-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This GitHub Action ensures that your naming conventions for commits, branches, and pull requests are being respected.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is a bug that doesn't allow blank lines in the commit message body if a min. length is set.

Fixes #1 