### PR TITLE
Revert merge commit names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ inputs:
     description: "Regular expression to check commit message subject"
     required: false
     default: |
-      ^(([A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [/\- ._,()A-Za-z0-9]*[)A-Za-z0-9]$
+      ^(((?!Merge)[A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [\- ._,()A-Za-z0-9]*[)A-Za-z0-9]|Merge[^\n]*$
   re-pull-request-title:
     description: "Regular expression to check pull request title"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ inputs:
     description: "Regular expression to check commit message subject"
     required: false
     default: |
-      ^(((?!Merge)[A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [\- ._,()A-Za-z0-9]*[)A-Za-z0-9]|Merge[^\n]*$
+      ^(([A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [/\- ._,()A-Za-z0-9]*[)A-Za-z0-9]$
   re-pull-request-title:
     description: "Regular expression to check pull request title"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   commit-message-body-max-length:
     description: "Max. length of commit message body"
     required: false
-    default: -1
+    default: 72
   commit-message-body-min-length:
     description: "Min. length of commit message body"
     required: false
@@ -15,7 +15,7 @@ inputs:
   commit-message-subject-max-length:
     description: "Max. length of commit message subject"
     required: false
-    default: -1
+    default: 72
   commit-message-subject-min-length:
     description: "Min. length of commit message subject"
     required: false
@@ -51,7 +51,8 @@ inputs:
   re-commit-author-name:
     description: "Regular expression to check commit author name"
     required: false
-    default: ".*"
+    default: |
+      ^[A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*( ((St\.|[Vv]an|[Dd]e[lr]?|[Ll]a)|[A-Z](\.|[a-z]+[A-Za-z]*)(-[A-Z](\.|[a-z]+[A-Za-z]*))*))*( [A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*)$
   re-commit-committer-email:
     description: "Regular expression to check commit author email"
     required: false
@@ -59,7 +60,8 @@ inputs:
   re-commit-committer-name:
     description: "Regular expression to check commit author name"
     required: false
-    default: ".*"
+    default: |
+      ^[A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*( ((St\.|[Vv]an|[Dd]e[lr]?|[Ll]a)|[A-Z](\.|[a-z]+[A-Za-z]*)(-[A-Z](\.|[a-z]+[A-Za-z]*))*))*( [A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*)$
   re-commit-message-body:
     description: "Regular expression to check commit message body"
     required: false
@@ -71,11 +73,13 @@ inputs:
   re-commit-message-subject:
     description: "Regular expression to check commit message subject"
     required: false
-    default: ".*"
+    default: |
+      ^(([A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [/\- ._,()A-Za-z0-9]*[)A-Za-z0-9]$
   re-pull-request-title:
     description: "Regular expression to check pull request title"
     required: false
-    default: ".*"
+    default: |
+      ^([A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: \b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [/\- ._,()A-Za-z0-9]*[)A-Za-z0-9]$
 runs:
   using: "node12"
   main: "index.js"

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: "Regular expression to check commit author name"
     required: false
     default: |
-      ^[A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*( ((St\.|[Vv]an|[Dd]e[lr]?|[Ll]a)|[A-Z](\.|[a-z]+[A-Za-z]*)(-[A-Z](\.|[a-z]+[A-Za-z]*))*))*( [A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*)$
+      ^(GitHub|[A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*( ((St\.|[Vv]an|[Dd]e[lr]?|[Ll]a)|[A-Z](\.|[a-z]+[A-Za-z]*)(-[A-Z](\.|[a-z]+[A-Za-z]*))*))*( [A-Z][a-z]+[A-Za-z]*(-[A-Z][a-z]+[A-Za-z]*)*))$
   re-commit-message-body:
     description: "Regular expression to check commit message body"
     required: false


### PR DESCRIPTION
Merge commits should not be used, so reverting this change. Instead use rebase to keep the history clean.